### PR TITLE
reset: exit if failed to retrive client

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -59,7 +59,7 @@ var resetCmd = &cobra.Command{
 				log.Println("[membership] Checking if this member was removed")
 				client, err := etcd.ClientForEndpoint(etcdAdmConfig.LoopbackClientURL.String(), &etcdAdmConfig)
 				if err != nil {
-					log.Printf("[membership] Error checking membership: %v", err)
+					log.Fatalf("[membership] Error checking membership: %v", err)
 				}
 				ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
 				mresp, err := client.MemberList(ctx)


### PR DESCRIPTION
fixing below SIGSEGV:
~/go/src/github.com/platform9/etcdadm>  ./etcdadm reset
INFO[0000] [reset] etcd service is running
INFO[0000] [membership] Checking if this member was removed
INFO[0000] [membership] Error checking membership: unable to create TLS client: open /etc/etcd/pki/etcdctl-etcd-client.key: permission denied
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xbafec3]

goroutine 1 [running]:
github.com/platform9/etcdadm/cmd.glob..func5(0x1320980, 0x134cd00, 0x0, 0x0)
	/home/nirmoy/go/src/github.com/platform9/etcdadm/cmd/reset.go:65 +0x863
github.com/platform9/etcdadm/vendor/github.com/spf13/cobra.(*Command).execute(0x1320980, 0x134cd00, 0x0, 0x0, 0x1320980, 0x134cd00)
	/home/nirmoy/go/src/github.com/platform9/etcdadm/vendor/github.com/spf13/cobra/command.go:766 +0x2c1
github.com/platform9/etcdadm/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x1320be0, 0xc420274700, 0xdd2c13, 0x6)
	/home/nirmoy/go/src/github.com/platform9/etcdadm/vendor/github.com/spf13/cobra/command.go:852 +0x30a
github.com/platform9/etcdadm/vendor/github.com/spf13/cobra.(*Command).Execute(0x1320be0, 0xc4200b0058, 0x0)
	/home/nirmoy/go/src/github.com/platform9/etcdadm/vendor/github.com/spf13/cobra/command.go:800 +0x2b
github.com/platform9/etcdadm/cmd.Execute()
	/home/nirmoy/go/src/github.com/platform9/etcdadm/cmd/root.go:47 +0x2d
main.main()
	/home/nirmoy/go/src/github.com/platform9/etcdadm/main.go:22 +0x20